### PR TITLE
Introducing Message to mark a field

### DIFF
--- a/src/tak/Client.java
+++ b/src/tak/Client.java
@@ -77,6 +77,9 @@ public class Client extends Thread {
     
     String resignString = "^Game#(\\d+) Resign";
     Pattern resignPattern;
+    
+    String markString = "^Game#(\\d+) (Mark|Unmark) ([A-Ha-h][1-8])";
+    Pattern markPattern;
 
     String seekString = "^Seek (\\d) (\\d+)";
     Pattern seekPattern;
@@ -157,6 +160,7 @@ public class Client extends Thread {
         drawPattern = Pattern.compile(drawString);
         removeDrawPattern = Pattern.compile(removeDrawString);
         resignPattern = Pattern.compile(resignString);
+        markPattern = Pattern.compile(markString);
         wrongRegisterPattern = Pattern.compile(wrongRegisterString);
         seekPattern = Pattern.compile(seekString);
         acceptSeekPattern = Pattern.compile(acceptSeekString);
@@ -487,6 +491,15 @@ public class Client extends Thread {
                             game = null;
                             other.game = null;
                         }
+                    }
+                    //Mark/Unmark target board field.
+                    else if (game != null && (m=markPattern.matcher(temp)).find() && game.no == Integer.parseInt(m.group(1))) {
+                      String function = m.group(2);
+                      String field = m.group(3).toLowerCase();
+                      if (game.setMarked(function.equals("Mark"), field, player))
+                            sendOK();
+                      else
+                            sendNOK();
                     }
                     //Show game state
                     else if (game != null && (m=gamePattern.matcher(temp)).find() && game.no == Integer.parseInt(m.group(1))) {

--- a/src/tak/Game.java
+++ b/src/tak/Game.java
@@ -122,6 +122,22 @@ public class Game {
             public String stackString() {
                 return stack.toString();
             }
+            public boolean isMarkedByPlayer()
+            {
+                return this.markedByPlayer;
+            }
+            public void setMarkedByPlayer(boolean marked)
+            {
+                this.markedByPlayer = marked;
+            }
+            public boolean isMarkedByObserver()
+            {
+                return this.markedByObserver;
+            }
+            public void setMarkedByObserver(boolean marked)
+            {
+                this.markedByObserver = marked;
+            }
         }
         Square[][] squares;
         
@@ -216,22 +232,6 @@ public class Game {
             }
             return sb.toString();
         }
-        public boolean isMarkedByPlayer()
-        {
-            return this.markedByPlayer;
-        }
-        public void setMarkedByPlayer(boolean marked)
-        {
-            this.markedByPlayer = marked;
-        }
-        public boolean isMarkedByObserver()
-        {
-            return this.markedByObserver;
-        }
-        public void setMarkedByObserver(boolean marked)
-        {
-            this.markedByObserver = marked;
-        }
     }
     
     Board board;
@@ -302,22 +302,22 @@ public class Game {
     boolean setMarked(boolean marked, String field, Player player) {
         int file = field.charAt(0) - 'a';
         int rank = field.charAt(1) - 1;
-        if (file < 0 || file >= this.boardSize
-            || rank < 0 || rank >= this.boardSize)
+        if (file < 0 || file >= this.board.boardSize
+            || rank < 0 || rank >= this.board.boardSize)
             return false;
         
         String msg;
         if (player == this.white || player == this.black) {
             msg = "Game#" + no
                     + (marked ? " Mark_Player " : " Unmark_Player ") + field;
-            this.board[rank][file].setMarkedByPlayer(marked);
+            this.board.squares[rank][file].setMarkedByPlayer(marked);
             sendToOtherPlayer(white, msg);
             sendToOtherPlayer(black, msg);
         }
         else {
             msg = "Game#" + no
                     + (marked ? " Mark_Observer " : " Unmark_Observer ") + field;
-            this.board[rank][file].setMarkedByObserver(marked);
+            this.board.squares[rank][file].setMarkedByObserver(marked);
         }
         sendToSpectators(msg);
         return true;
@@ -397,13 +397,15 @@ public class Game {
     }
     
     void sendMarkedListTo(Client c) {
-      for(int i = 0; i < boardSize; ++i)
-        for (int j = 0; j < boardSize; ++j)
+      for(int i = 0; i < this.board.boardSize; ++i)
+        for (int j = 0; j < this.board.boardSize; ++j)
         {
-          if (this.board[i][j].isMarkedByPlayer())
-            c.sendWithoutLogging("Mark_Player " + ((char) (j + 'a')) + (i + 1));
-          if (this.board[i][j].isMarkedByObserver())
-            c.sendWithoutLogging("Mark_Observer " + ((char) (j + 'a')) + (i + 1));
+          if (this.board.squares[i][j].isMarkedByPlayer())
+            c.sendWithoutLogging("Game#" + this.no + " Mark_Player "
+                + ((char) (j + 'a')) + (i + 1));
+          if (this.board.squares[i][j].isMarkedByObserver())
+            c.sendWithoutLogging("Game#" + this.no + " Mark_Observer "
+                + ((char) (j + 'a')) + (i + 1));
         }
     }
     

--- a/src/tak/Game.java
+++ b/src/tak/Game.java
@@ -67,6 +67,8 @@ public class Game {
         private int file, row;
         private ArrayList<Character> stack;
         int graphNo;
+        boolean markedByPlayer = false;
+        boolean markedByObserver = false;
         
         Square(int f, int r) {
             stack = new ArrayList<>();
@@ -117,6 +119,22 @@ public class Game {
         
         public String stackString() {
             return stack.toString();
+        }
+        public boolean isMarkedByPlayer()
+        {
+            return this.markedByPlayer;
+        }
+        public void setMarkedByPlayer(boolean marked)
+        {
+            this.markedByPlayer = marked;
+        }
+        public boolean isMarkedByObserver()
+        {
+            return this.markedByObserver;
+        }
+        public void setMarkedByObserver(boolean marked)
+        {
+            this.markedByObserver = marked;
         }
     }
     Square[][] board;
@@ -196,6 +214,7 @@ public class Game {
     void newSpectator(Client c) {
         c.send("Observe "+shortDesc());
         sendMoveListTo(c);
+        sendMarkedListTo(c);
         spectators.add(c);
         updateTime(c);
     }
@@ -206,6 +225,30 @@ public class Game {
         else
             gameState = gameS.WHITE;
         whenGameEnd();
+    }
+    
+    boolean setMarked(boolean marked, String field, Player player) {
+        int file = field.charAt(0) - 'a';
+        int rank = field.charAt(1) - 1;
+        if (file < 0 || file >= this.boardSize
+            || rank < 0 || rank >= this.boardSize)
+            return false;
+        
+        String msg;
+        if (player == this.white || player == this.black) {
+            msg = "Game#" + no
+                    + (marked ? " Mark_Player " : " Unmark_Player ") + field;
+            this.board[rank][file].setMarkedByPlayer(marked);
+            sendToOtherPlayer(white, msg);
+            sendToOtherPlayer(black, msg);
+        }
+        else {
+            msg = "Game#" + no
+                    + (marked ? " Mark_Observer " : " Unmark_Observer ") + field;
+            this.board[rank][file].setMarkedByObserver(marked);
+        }
+        sendToSpectators(msg);
+        return true;
     }
     
     Square[][] getClonedBoard(Square[][] orig) {
@@ -306,6 +349,17 @@ public class Game {
     void sendMoveListTo(Client c) {
         for(String move:moveList)
             c.sendWithoutLogging("Game#"+no+" "+move);
+    }
+    
+    void sendMarkedListTo(Client c) {
+      for(int i = 0; i < boardSize; ++i)
+        for (int j = 0; j < boardSize; ++j)
+        {
+          if (this.board[i][j].isMarkedByPlayer())
+            c.sendWithoutLogging("Mark_Player " + ((char) (j + 'a')) + (i + 1));
+          if (this.board[i][j].isMarkedByObserver())
+            c.sendWithoutLogging("Mark_Observer " + ((char) (j + 'a')) + (i + 1));
+        }
     }
     
     String shortDesc(){


### PR DESCRIPTION
The marked field can be marked (if the client recognizes the message)
Can be used in the production of video-blogs or strategy discussion, or
as a means to call Tak! on a specific field.

Markings can be set by players and Observers. Observers see all markings,
players only player markings. This prevents interference in the game.
A field can be marked by both player and observer. It is up to the client
to properly treat this state.
The marking of fields is game specific in preparation for players being
able to play multiple games simultaniously.
