### PR TITLE
get server game IDs from sqlite

### DIFF
--- a/src/tak/TakServer.java
+++ b/src/tak/TakServer.java
@@ -40,13 +40,12 @@ public class TakServer extends Thread{
         Settings.parse();
         Database.initConnection();
         Player.loadFromDB();
-        Game.setGameNo();
-        
+
         IRCBridge.init();
-        
+
         if(args.length>0)
             port = Integer.parseInt(args[0]);
-        
+
         TakServer takServer = new TakServer();
         takServer.start();
         TakServer.Log("dir: "+System.getProperty("user.dir"));


### PR DESCRIPTION
Insert games into the database on creation, instead of completion. This
lets us read back the game ID and use that for the server protocol. This
lets bots and other clients easily correlate their games with the
exposed server database.

In this implementation, games that have not yet finished (or never finished, due to server crash) are stored with a `NULL` notation and result.

fixes #18 
