### PR TITLE
Fix a ConcurrentModificationException

### DIFF
--- a/src/tak/Seek.java
+++ b/src/tak/Seek.java
@@ -72,10 +72,11 @@ public class Seek {
     }
     
     static void updateListeners(final String st) {
+        final Set<Client> snapshot = new HashSet<Client>(seekListeners);
         new Thread() {
             @Override
             public void run() {
-                for (Client cc : seekListeners) {
+                for (Client cc : snapshot) {
                     cc.sendWithoutLogging("Seek " + st);
                 }
             }


### PR DESCRIPTION
I saw this in local testing:

```
Exception in thread "Thread-56" java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437)
        at java.util.HashMap$KeyIterator.next(HashMap.java:1461)
        at tak.Seek$1.run(Seek.java:78)
```

The problem comes from the iteration over `seekListeners`; As
[documented](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedSet(java.util.Set)),
a `synchronizedSet` still must be explicitly synchronized for iteration.

Instead of synchronizing, make a copy before spawning the thread, so
that mutations can occur on the canonical copy while the thread
dispatches notifications in the background.